### PR TITLE
Add CircleCI support with CMake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,274 @@
+
+# Default configuration
+
+defaults: &defaults
+  docker:
+    - image: debian:stretch
+
+# Install Aliases
+
+_install: &install
+  name: Install
+  command: bash ci/install.sh
+
+_cmake:
+  cmake_latest: &install_cmake_latest
+    name: Install CMake Latest
+    command: bash ci/install_cmake.sh latest
+  cmake3_11: &install_cmake3_11
+    name: Install CMake 3.11
+    command: bash ci/install_cmake.sh 3.11.4
+
+_boost:
+  boost_latest: &install_boost_latest
+    name: Install Boost Latest
+    command: bash ci/install_boost.sh latest
+  boost1_66: &install_boost1_66
+    name: Install Boost 1.66
+    command: bash ci/install_boost.sh 1.66.0
+  boost1_61: &install_boost1_61
+    name: Install Boost 1.61
+    command: bash ci/install_boost.sh 1.61.0
+
+_openexr:
+  openexr_latest: &install_openexr_latest
+    name: Install OpenEXR Latest
+    command: bash ci/install_openexr.sh latest
+  openexr2_3: &install_openexr2_3
+    name: Install OpenEXR 2.3.0
+    command: bash ci/install_openexr.sh 2.3.0
+  openexr2_2: &install_openexr2_2
+    name: Install OpenEXR 2.2.0
+    command: bash ci/install_openexr.sh 2.2.0
+
+_tbb:
+  tbb_latest: &install_tbb_latest
+    name: Install TBB Latest
+    command: bash ci/install_tbb.sh latest
+  tbb2018: &install_tbb2018
+    name: Install TBB 2018
+    command: bash ci/install_tbb.sh 2018
+  tbb2017: &install_tbb2017
+    name: Install TBB 2017
+    command: bash ci/install_tbb.sh 2017_U6
+  tbb4_4: &install_tbb4_4
+    name: Install TBB 4.4
+    command: bash ci/install_tbb.sh 4.4
+
+_blosc:
+  blosc_latest: &install_blosc_latest
+    name: Install Blosc Latest
+    command: bash ci/install_blosc.sh latest
+  blosc1_5: &install_blosc1_5
+    name: Install Blosc 1.5.0
+    command: bash ci/install_blosc.sh 1.5.0
+
+_houdini:
+  houdini17_5: &install_houdini17_5
+    name: Install Houdini 17.5
+    command: bash ci/install_houdini.sh 17.5
+  houdini17_0: &install_houdini17_0
+    name: Install Houdini 17.0
+    command: bash ci/install_houdini.sh 17.0
+  houdini16_5: &install_houdini16_5
+    name: Install Houdini 16.5
+    command: bash ci/install_houdini.sh 16.5
+
+# Build and Test Aliases
+
+_build_core:
+  abi6: &build_abi6
+    name: Build ABI 6
+    command: bash ci/build.sh clang++ Release 6 ON
+  abi5: &build_abi5
+    name: Build ABI 5
+    command: bash ci/build.sh clang++ Release 5 ON
+  abi4: &build_abi4
+    name: Build ABI 4
+    command: bash ci/build.sh clang++ Release 4 ON
+  abi6_debug: &build_abi6_debug
+    name: Build ABI 6 (Debug)
+    command: bash ci/build.sh clang++ Debug 6 ON
+  abi6_gcc: &build_abi6_gcc
+    name: Build ABI 6 (GCC)
+    command: bash ci/build.sh g++ Release 6 ON
+  abi6_no_blosc: &build_abi6_no_blosc
+    name: Build ABI 6 (No Blosc)
+    command: bash ci/build.sh clang++ Release 6 OFF
+
+_build_houdini:
+  houdini: &build_houdini
+    name: Build Houdini
+    command: bash ci/build_houdini.sh clang++ Release OFF
+    no_output_timeout: 1200
+  houdini_al: &build_houdini_all
+    name: Build Houdini
+    command: bash ci/build_houdini.sh clang++ Release ON
+    no_output_timeout: 1200
+  houdini_debug: &build_houdini_debug
+    name: Build Houdini (Debug)
+    command: bash ci/build_houdini.sh clang++ Debug OFF
+    no_output_timeout: 1200
+  houdini_gcc: &build_houdini_gcc
+    name: Build Houdini (GCC)
+    command: bash ci/build_houdini.sh g++ Release OFF
+    no_output_timeout: 1200
+
+_test:
+  test: &test
+    name: Unit Tests
+    command: ./build/openvdb/unittest/vdb_test -v
+
+# Jobs
+
+# TODO: testabi5, testabi4, testhou175 need OpenEXR makefile support for 2.2
+
+version: 2.1
+jobs:
+  testabi6latest:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: *install
+      - run: *install_cmake_latest
+      - run: *install_boost_latest
+      - run: *install_tbb_latest
+      - run: *install_openexr_latest
+      - run: *install_blosc_latest
+      - run: *build_abi6
+      - run: *test
+
+  testabi6:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: *install
+      - run: *install_cmake3_11
+      - run: *install_boost1_66
+      - run: *install_tbb2018
+      - run: *install_openexr2_3
+      - run: *install_blosc1_5
+      - run: *build_abi6
+      - run: *test
+
+  testabi6debug:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: *install
+      - run: *install_cmake3_11
+      - run: *install_boost1_66
+      - run: *install_tbb2018
+      - run: *install_openexr2_3
+      - run: *install_blosc1_5
+      - run: *build_abi6_debug
+
+  testabi6gcc:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: *install
+      - run: *install_cmake3_11
+      - run: *install_boost1_66
+      - run: *install_tbb2018
+      - run: *install_openexr2_3
+      - run: *install_blosc1_5
+      - run: *build_abi6_gcc
+
+  testabi6noblosc:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: *install
+      - run: *install_cmake3_11
+      - run: *install_boost1_66
+      - run: *install_tbb2018
+      - run: *install_openexr2_3
+      - run: *build_abi6_no_blosc
+
+  testabi5:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: *install
+      - run: *install_boost1_61
+      - run: *install_tbb2017
+      - run: *install_openexr2_3
+      - run: *install_blosc1_5
+      - run: *build_abi5
+      - run: *test
+
+  testabi4:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: *install
+      - run: *install_boost1_61
+      - run: *install_tbb4_4
+      - run: *install_openexr2_3
+      - run: *install_blosc1_5
+      - run: *build_abi4
+      - run: *test
+
+  testhou175:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: *install
+      - run: *install_houdini17_5
+      - run: *install_boost1_61
+      - run: *build_houdini_all
+
+  testhou175debug:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: *install
+      - run: *install_houdini17_5
+      - run: *install_boost1_61
+      - run: *build_houdini_debug
+
+  testhou175gcc:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: *install
+      - run: *install_houdini17_5
+      - run: *install_boost1_61
+      - run: *build_houdini_gcc
+
+  testhou170:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: *install
+      - run: *install_houdini17_0
+      - run: *install_boost1_61
+      - run: *build_houdini
+
+  testhou165:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: *install
+      - run: *install_houdini16_5
+      - run: *install_boost1_61
+      - run: *build_houdini
+
+# Workflows
+
+workflows:
+  build_and_test:
+    jobs:
+      - testabi6
+      - testabi5
+      - testabi4
+      - testabi6debug
+      - testabi6gcc
+      - testabi6noblosc
+      - testhou175
+      - testhou170
+      - testhou165
+      - testhou175debug
+      - testhou175gcc
+      # - testabi6latest # work-in-progress

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -ex
+
+COMPILER="$1"
+RELEASE="$2"
+ABI="$3"
+BLOSC="$4"
+
+mkdir build
+cd build
+cmake \
+    -DCMAKE_CXX_COMPILER=${COMPILER} \
+    -DCMAKE_BUILD_TYPE=${RELEASE} \
+    -DOPENVDB_ABI_VERSION_NUMBER=${ABI} \
+    -DUSE_BLOSC=${BLOSC} \
+    ..
+make -j2
+make install

--- a/ci/build_houdini.sh
+++ b/ci/build_houdini.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -ex
+
+COMPILER="$1"
+RELEASE="$2"
+EXTRAS="$3"
+
+cd hou
+source houdini_setup_bash
+cd -
+
+mkdir build
+cd build
+cmake \
+    -DCMAKE_CXX_COMPILER=${COMPILER} \
+    -DCMAKE_BUILD_TYPE=${RELEASE} \
+    -DOPENVDB_BUILD_HOUDINI_PLUGIN=ON \
+    -DOPENVDB_BUILD_BINARIES=${EXTRAS} \
+    -DOPENVDB_BUILD_PYTHON_MODULE=${EXTRAS} \
+    -DOPENVDB_BUILD_UNITTESTS=${EXTRAS} \
+     ..
+
+# Can only build using one thread with GCC due to memory constraints
+if [ "$COMPILER" = "clang++" ]; then
+    make -j2
+else
+    make
+fi
+make install

--- a/ci/download_houdini.py
+++ b/ci/download_houdini.py
@@ -1,0 +1,54 @@
+# Python script to download the latest Houdini production builds
+#
+# Note that this can now be replaced with this API:
+# https://www.sidefx.com/docs/api/download/index.html
+#
+# Author: Dan Bailey
+
+import mechanize
+import sys
+import re
+import exceptions
+
+# this argument is for the major.minor version of Houdini to download (such as 15.0, 15.5, 16.0)
+version = sys.argv[1]
+
+if not re.match('[0-9][0-9]\.[0-9]$', version):
+    raise IOError('Invalid Houdini Version "%s", expecting in the form "major.minor" such as "16.0"' % version)
+
+br = mechanize.Browser()
+br.set_handle_robots(False)
+
+# login to sidefx.com as openvdb
+br.open('https://www.sidefx.com/login/?next=/download/daily-builds')
+br.select_form(nr=0)
+br.form['username'] = 'openvdb'
+br.form['password'] = 'L3_M2f2W'
+br.submit()
+
+# retrieve download id
+br.open('https://www.sidefx.com/download/daily-builds/')
+
+houid = -1
+
+for link in br.links():
+    if '/download/download-houdini' not in link.url:
+        continue
+    if link.text.startswith('houdini-%s' % version) and 'linux_x86_64' in link.text:
+        response = br.follow_link(text=link.text, nr=0)
+        url = response.geturl()
+        houid = url.split('/download-houdini/')[-1]
+        break
+
+# download houdini tarball in 50MB chunks
+url = 'https://www.sidefx.com/download/download-houdini/%sget/' % houid
+response = br.open(url)
+mb = 1024*1024
+chunk = 50
+size = 0
+file = open('hou.tar.gz', 'wb')
+for bytes in iter((lambda: response.read(chunk*mb)), ''):
+    size += 50
+    print 'Read: %sMB' % size
+    file.write(bytes)
+file.close()

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -ex
+
+apt-get update
+
+apt-get install -y zlib1g-dev
+apt-get install -y wget
+apt-get install -y unzip
+apt-get install -y curl
+apt-get install -y cmake
+apt-get install -y git
+apt-get install -y g++
+apt-get install -y clang
+apt-get install -y llvm
+apt-get install -y pkg-config
+apt-get install -y libglu1-mesa-dev
+apt-get install -y libgl1-mesa-dev
+apt-get install -y libcppunit-dev
+apt-get install -y liblog4cplus-dev
+apt-get install -y libglfw3-dev
+apt-get install -y python-dev
+apt-get install -y python-numpy
+apt-get install -y python-epydoc
+apt-get install -y doxygen

--- a/ci/install_blosc.sh
+++ b/ci/install_blosc.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -ex
+
+BLOSC_VERSION="$1"
+
+git clone https://github.com/Blosc/c-blosc.git
+cd c-blosc
+
+if [ "$BLOSC_VERSION" != "latest" ]; then
+    git checkout tags/v${BLOSC_VERSION} -b v${BLOSC_VERSION}
+fi
+
+mkdir build
+cd build
+cmake ../.
+make -j4
+make install

--- a/ci/install_boost.sh
+++ b/ci/install_boost.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -ex
+
+BOOST_VERSION="$1"
+
+# only install for Boost 1.61
+apt-get install -y libbz2-dev
+
+git clone https://github.com/boostorg/boost.git
+cd boost
+
+if [ "$BOOST_VERSION" == "latest" ]; then
+    git checkout tags/boost-1.69.0 -b boost-1.69.0
+else
+    git checkout tags/boost-${BOOST_VERSION} -b boost-${BOOST_VERSION}
+fi
+
+git submodule update --init --
+
+./bootstrap.sh --prefix=/usr/local
+./b2 headers -j4
+./b2 install link=shared variant=release \
+    --with-atomic \
+    --with-chrono \
+    --with-date_time \
+    --with-iostreams \
+    --with-python \
+    --with-regex \
+    --with-system \
+    --with-thread \
+    -j4

--- a/ci/install_cmake.sh
+++ b/ci/install_cmake.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -ex
+
+CMAKE_VERSION="$1"
+
+git clone https://github.com/Kitware/CMake.git
+cd CMake
+
+if [ "$CMAKE_VERSION" != "latest" ]; then
+    git checkout tags/v${CMAKE_VERSION} -b v${CMAKE_VERSION}
+fi
+
+mkdir build
+cd build
+cmake ../.
+make -j4
+make install

--- a/ci/install_houdini.sh
+++ b/ci/install_houdini.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -ex
+
+HOUDINI_MAJOR="$1"
+
+# install houdini pre-requisites
+apt-get install -y libxi-dev
+apt-get install -y csh
+apt-get install -y default-jre
+apt-get install -y python-mechanize
+
+export PYTHONPATH=${PYTHONPATH}:/usr/lib/python2.7/dist-packages
+# download and unpack latest houdini headers and libraries from daily-builds
+python ci/download_houdini.py $HOUDINI_MAJOR
+
+tar -xzf hou.tar.gz
+ln -s houdini* hou
+cd hou
+tar -xzf houdini.tar.gz
+
+cd -

--- a/ci/install_openexr.sh
+++ b/ci/install_openexr.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -ex
+
+OPENEXR_VERSION="$1"
+
+git clone https://github.com/openexr/openexr.git
+cd openexr
+
+if [ "$OPENEXR_VERSION" != "latest" ]; then
+    git checkout tags/v${OPENEXR_VERSION} -b v${OPENEXR_VERSION}
+fi
+
+# TODO: CMake support was only introduced with OpenEXR 2.3, expand this to use 2.2
+
+mkdir build
+cd build
+cmake -DOPENEXR_BUILD_PYTHON_LIBS=OFF -DOPENEXR_BUILD_TESTS=OFF -DOPENEXR_BUILD_UTILS=OFF ../.
+make -j4
+make install

--- a/ci/install_tbb.sh
+++ b/ci/install_tbb.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -ex
+
+TBB_VERSION="$1"
+
+git clone https://github.com/01org/tbb.git
+cd tbb
+
+if [ "$TBB_VERSION" != "latest" ]; then
+    git checkout tags/${TBB_VERSION} -b ${TBB_VERSION}
+fi
+
+make -j4
+cp -r include/serial /usr/local/include/.
+cp -r include/tbb /usr/local/include/.
+cp -r build/*/*.so* /usr/local/lib/.


### PR DESCRIPTION
@Idclip - this adds Circle CI support to your CMake changes, I thought I'd open this as a PR into your fork rather than add these changes directly because there's quite a lot of them.

This supports building standalone ABI=6, ABI=5, ABI=4 as well as Houdini 17.5, 17.0, 16.5. It builds all of it's dependencies from scratch right now to try and best match the VFX Reference Platform, however there are a few remaining things to resolve:

* CMake 3.10.1 was the first release to support Boost 1.66 using FindBoost, so I think I need to update the version of CMake used in order to support the Boost version required in VFX Reference Platform 2019. I believe it picks up the default which is 3.7.3. Perhaps it's worth also using the earliest version of CMake as well for the other years, just to make sure that we're fully compatible.
* OpenEXR only introduced CMake support in 2.3.0 and I haven't got around to adding support to build it prior to that, so can't fully support VFX 2018/2017 yet.
* Houdini 17.5 ships with Imath/OpenEXR namespaced such as libImath_sidefx.so which I don't believe the CMake FindIlmBase modules can handle yet - I'm also not sure about the best way of supporting this?
* Docker images - I'd like to publish Docker images for VFX 2019/2018/2017 that has pre-installed all the non-VFX dependencies (Boost, TBB, etc), then re-use them here. It may even be possible to build out a latest top-of-tree build using Docker too.
* OpenEXR currently builds the whole library which includes some slow portions (the DWA compressor in particular). I'd like to push a change to OpenEXR to be able to optionally disable this when building as we don't support writing EXRs with this compression scheme in OpenVDB.

Also, I'd like to add a test job that builds everything at the latest top-of-tree. Ideally this is something we could run once a week or once a day or so to verify that any changes coming down the pipe don't cause issues for us.